### PR TITLE
Successful 07/27 checkpoint

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -186,8 +186,7 @@
 	platforms = cc13xx_26xx
 [submodule "third_party/silabs/matter_support"]
 	path = third_party/silabs/matter_support
-	url = https://github.com/SiliconLabsSoftware/matter_support.git
-	branch = main
+	url = git@github.com:suveshpratapa/matter_support.git
 	platforms = silabs,silabs_docker,unit_tests
 [submodule "editline"]
 	path = third_party/editline/repo

--- a/examples/light-switch-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/light-switch-app/silabs/include/CHIPProjectConfig.h
@@ -96,3 +96,7 @@
 
 // Temporary setting to use CustomerAppTask for apps which are not upgraded to new architecture
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
+
+// Disable BLE advertising for Thread Direct pre-commissioned demo.
+// TODO: Revisit for full scope use cases.
+#define CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART 0

--- a/examples/light-switch-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/light-switch-app/silabs/include/CHIPProjectConfig.h
@@ -60,13 +60,6 @@
 #define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0x8004
 
 /**
- * CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
- *
- * Enable support for Chip-over-BLE (CHIPoBLE).
- */
-#define CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE 1
-
-/**
  * CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER
  *
  * Enables the use of a hard-coded default serial number if none

--- a/examples/light-switch-app/silabs/openthread.gni
+++ b/examples/light-switch-app/silabs/openthread.gni
@@ -50,3 +50,6 @@ chip_address_resolve_strategy = "custom"
 chip_openthread_thread_direct_wake_initiator_enable = true
 chip_openthread_thread_direct_wake_listener_enable = false
 sl_use_thread_direct = true
+
+# Disabling BLE removes BLE/Thread radio arbitration from the Thread Direct data path.
+chip_config_network_layer_ble = false

--- a/examples/light-switch-app/silabs/openthread.gni
+++ b/examples/light-switch-app/silabs/openthread.gni
@@ -51,5 +51,4 @@ chip_openthread_thread_direct_wake_initiator_enable = true
 chip_openthread_thread_direct_wake_listener_enable = false
 sl_use_thread_direct = true
 
-# Disabling BLE removes BLE/Thread radio arbitration from the Thread Direct data path.
-chip_config_network_layer_ble = false
+chip_config_network_layer_ble = true

--- a/examples/lighting-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/silabs/include/CHIPProjectConfig.h
@@ -66,13 +66,6 @@
 #define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0x8005
 
 /**
- * CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
- *
- * Enable support for Chip-over-BLE (CHIPoBLE).
- */
-#define CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE 1
-
-/**
  * CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER
  *
  * Enables the use of a hard-coded default serial number if none

--- a/examples/lighting-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/silabs/include/CHIPProjectConfig.h
@@ -102,3 +102,7 @@
 
 // This is a temporary setting to use the CustomerAppTask for the apps which are not upgraded to the new architecture.
 #define CHIP_SILABS_APP_USE_CUSTOMER_APP_TASK
+
+// Disable BLE advertising for Thread Direct pre-commissioned demo.
+// TODO: Revisit for full scope use cases.
+#define CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART 0

--- a/examples/lighting-app/silabs/openthread.gni
+++ b/examples/lighting-app/silabs/openthread.gni
@@ -38,5 +38,4 @@ chip_openthread_thread_direct_wake_initiator_enable = false
 chip_openthread_thread_direct_wake_listener_enable = true
 sl_use_thread_direct = true
 
-# Disabling BLE removes BLE/Thread radio arbitration from the Thread Direct data path.
-chip_config_network_layer_ble = false
+chip_config_network_layer_ble = true

--- a/examples/lighting-app/silabs/openthread.gni
+++ b/examples/lighting-app/silabs/openthread.gni
@@ -37,3 +37,6 @@ chip_address_resolve_strategy = "custom"
 chip_openthread_thread_direct_wake_initiator_enable = false
 chip_openthread_thread_direct_wake_listener_enable = true
 sl_use_thread_direct = true
+
+# Disabling BLE removes BLE/Thread radio arbitration from the Thread Direct data path.
+chip_config_network_layer_ble = false

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -664,30 +664,30 @@ void BaseApplication::ButtonHandler(AppEvent * aEvent)
             // - Cycle LCD screen
             CancelFunctionTimer();
 
-#ifdef SL_WIFI
-            if (!ConnectivityMgr().IsWiFiStationProvisioned())
-#else
-            if (!BaseApplication::sIsProvisioned)
-#endif /* !SL_WIFI */
-            {
-                // Open Basic CommissioningWindow. Will start BLE advertisements
-                chip::DeviceLayer::PlatformMgr().LockChipStack();
-                CHIP_ERROR err = chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow();
-                chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-                if (err != CHIP_NO_ERROR)
-                {
-                    ChipLogError(AppServer, "Failed to open the Basic Commissioning Window");
-                }
-            }
-            else
-            {
-                ChipLogProgress(AppServer, "Network is already provisioned, Ble advertisement not enabled");
-#if CHIP_CONFIG_ENABLE_ICD_SERVER
-                // Temporarily claim network activity, until we implement a "user trigger" reason for ICD wakeups.
-                TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(
-                    [](intptr_t) { ICDNotifier::GetInstance().NotifyNetworkActivityNotification(); });
-#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
-            }
+// #ifdef SL_WIFI
+//             if (!ConnectivityMgr().IsWiFiStationProvisioned())
+// #else
+//             if (!BaseApplication::sIsProvisioned)
+// #endif /* !SL_WIFI */
+//             {
+//                 // Open Basic CommissioningWindow. Will start BLE advertisements
+//                 chip::DeviceLayer::PlatformMgr().LockChipStack();
+//                 CHIP_ERROR err = chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow();
+//                 chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+//                 if (err != CHIP_NO_ERROR)
+//                 {
+//                     ChipLogError(AppServer, "Failed to open the Basic Commissioning Window");
+//                 }
+//             }
+//             else
+//             {
+//                 ChipLogProgress(AppServer, "Network is already provisioned, Ble advertisement not enabled");
+// #if CHIP_CONFIG_ENABLE_ICD_SERVER
+//                 // Temporarily claim network activity, until we implement a "user trigger" reason for ICD wakeups.
+//                 TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(
+//                     [](intptr_t) { ICDNotifier::GetInstance().NotifyNetworkActivityNotification(); });
+// #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+//             }
             // Print the QR Code
             OutputQrCode(false);
 #ifdef DISPLAY_ENABLED
@@ -1004,11 +1004,11 @@ void BaseApplication::DoProvisioningReset()
         chip::DeviceLayer::ConnectivityMgr().ClearWiFiStationProvision();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
 
-        CHIP_ERROR err = Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow();
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(AppServer, "Failed to open the Basic Commissioning Window");
-        }
+//         CHIP_ERROR err = Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow();
+//         if (err != CHIP_NO_ERROR)
+//         {
+//             ChipLogError(AppServer, "Failed to open the Basic Commissioning Window");
+//         }
     });
 }
 

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -295,9 +295,11 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to Init Chip Stack: %" CHIP_ERROR_FORMAT, err.Format()));
 
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
     err = chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(appName);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to Set BLE Device Name: %" CHIP_ERROR_FORMAT, err.Format()));
+#endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
     // Provision Manager
     Provision::Manager & provision = Provision::Manager::GetInstance();

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -19,6 +19,8 @@
 #include "SoftwareFaultReports.h"
 #include "FreeRTOSConfig.h"
 #include "silabs_utils.h"
+#include <FreeRTOS.h>
+#include <task.h>
 #ifdef MATTER_DM_PLUGIN_SOFTWARE_DIAGNOSTICS_SERVER
 #include <app/clusters/software-diagnostics-server/software-fault-listener.h>
 #endif // MATTER_DM_PLUGIN_SOFTWARE_DIAGNOSTICS_SERVER

--- a/examples/platform/silabs/silabs_utils.cpp
+++ b/examples/platform/silabs/silabs_utils.cpp
@@ -19,7 +19,9 @@
 
 #include "silabs_utils.h"
 #include "SoftwareFaultReports.h"
+#include <FreeRTOS.h>
 #include <MatterConfig.h>
+#include <task.h>
 
 void appError(int err)
 {

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -19,9 +19,11 @@
 #ifdef ENABLE_CHIP_SHELL
 #include "MatterShell.h" // nogncheck
 #endif
+#include <FreeRTOS.h>
 #include <cmsis_os2.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <sl_cmsis_os2_common.h>
+#include <task.h>
 
 #include <platform/silabs/Logging.h>
 

--- a/precommission/provisioning-config-light-dataset-working.yaml
+++ b/precommission/provisioning-config-light-dataset-working.yaml
@@ -1,0 +1,62 @@
+# Unified provisioning configuration.
+# All sections share the same key/value schema. Thread sections use NVM3 object
+# keys (hex integers); MatterFabric uses KVS string keys. Values are hex strings.
+configs:
+  ThreadActiveDataset:
+    entries:
+      - type: active_timestamp
+        seconds: 1
+        ticks: 0
+        authoritative: false
+      - type: channel
+        page: 0
+        channel: 25
+      - type: wakeup_channel
+        page: 0
+        channel: 20
+      - type: channel_mask
+        entries:
+        - page: 0
+          mask: 001fffe0
+      - type: ext_pan_id
+        value: deadbeefcafe0001
+      - type: network_key
+        value: deadbeefcafebabe0011223344556677
+      - type: network_name
+        value: ThreadDirect
+      - type: pan_id
+        value: '0xd001'
+        
+  PreCommissioning:
+    entries:
+      - key: "0x708"
+        value: "044ad0a1451a688901668eff54a27823f945cf68d6b1ef941d95029e46c632f884a5fbab6b15ebcfe1ad40e840eafb5f8f707cf8d60f2ddfbfd0cd14bc6042b35611423473ab058e67e2ceb4612da334835a8fdbf8054879fd63038e9f0d0f240e"
+      - key: "0x70A"
+        value: "61000000"
+      
+  TargetConnectionParameters:
+    entries:
+      - key: "0x700"
+        description: "Target extended address"
+        value: "1e806b6588a24908"
+      - key: "0x701"
+        description: "Target address: Switch here"
+        value: "fdf6:5d1c:8822:6404:0:ff:fe00:401"
+      - key: "0x702"
+        description: "Target port"
+        value: "a415" # 5540
+      - key: "0x703"
+        description: "MRP Remote Idle Interval"
+        value: "d0070000" # 2000
+      - key: "0x704"
+        description: "MRP Remote Active Interval"
+        value: "d0070000" # 2000
+      - key: "0x705"
+        description: "MRP Remote Active Threshold Time"
+        value: "a00f0000" # 4000
+      - key: "0x706"
+        description: "Compressed Fabric ID"
+        value: "d66725f89b82e913" # 13E9829BF82567D6
+      - key: "0x707"
+        description: "Node ID"
+        value: "0200000000000000" # 2

--- a/precommission/provisioning-config-switch-dataset-working.yaml
+++ b/precommission/provisioning-config-switch-dataset-working.yaml
@@ -1,0 +1,61 @@
+# Unified provisioning configuration.
+# All sections share the same key/value schema. Thread sections use NVM3 object
+# keys (hex integers); MatterFabric uses KVS string keys. Values are hex strings.
+configs:
+  ThreadActiveDataset:
+    entries:
+      - type: active_timestamp
+        seconds: 1
+        ticks: 0
+        authoritative: false
+      - type: channel
+        page: 0
+        channel: 25
+      - type: wakeup_channel
+        page: 0
+        channel: 20
+      - type: channel_mask
+        entries:
+        - page: 0
+          mask: 001fffe0
+      - type: ext_pan_id
+        value: deadbeefcafe0001
+      - type: network_key
+        value: deadbeefcafebabe0011223344556677
+      - type: network_name
+        value: ThreadDirect
+      - type: pan_id
+        value: '0xd001'
+
+  PreCommissioning:
+    entries:
+      - key: "0x708"
+        description: "Operational key"
+        value: "04b37192af92eac82a29329b99c1f953fb1916f82698af67f3ab086be10448d24f73c913f33b683bdd1f1500f90ba27409a7b77b5e5cfc435157d11dc49f87c99d2fc78c6b2fb04bebe220286dbbbd412639a702ed9e2765427571be70291b258d"
+      
+  TargetConnectionParameters:
+    entries:
+      - key: "0x700"
+        description: "Target extended address"
+        value: "3a2e40e0a05448f5"
+      - key: "0x701"
+        description: "Target address: Light here"
+        value: "fdf6:5d1c:8822:6404:0:ff:fe00:ec00"
+      - key: "0x702"
+        description: "Target port"
+        value: "a415" # 5540
+      - key: "0x703"
+        description: "MRP Remote Idle Interval"
+        value: "d0070000" # 2000
+      - key: "0x704"
+        description: "MRP Remote Active Interval"
+        value: "d0070000" # 2000
+      - key: "0x705"
+        description: "MRP Remote Active Threshold Time"
+        value: "a00f0000" # 4000
+      - key: "0x706"
+        description: "Compressed Fabric ID"
+        value: "d66725f89b82e913" # 13E9829BF82567D6
+      - key: "0x707"
+        description: "Node ID"
+        value: "0200000000000000" # 2

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -560,10 +560,10 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
         TEMPORARY_RETURN_IGNORED DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false);
 #endif
     }
-    else if (initParams.advertiseCommissionableIfNoFabrics)
-    {
-        SuccessOrExit(err = mCommissioningWindowManager.OpenBasicCommissioningWindow(initParams.discoveryTimeout));
-    }
+//     else if (initParams.advertiseCommissionableIfNoFabrics)
+//     {
+//         SuccessOrExit(err = mCommissioningWindowManager.OpenBasicCommissioningWindow(initParams.discoveryTimeout));
+//     }
 
     // TODO @bzbarsky-apple @cecille Move to examples
     // ESP32 examples have a custom logic for enabling DNS-SD

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -170,7 +170,8 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
         chip_device_platform == "tizen" || chip_device_platform == "android" ||
         chip_device_platform == "webos" || chip_device_platform == "bl602" ||
         chip_device_platform == "bl702" || chip_device_platform == "bl702l" ||
-        chip_device_platform == "bl616" || chip_device_platform == "esp32") {
+        chip_device_platform == "bl616" || chip_device_platform == "esp32" ||
+        chip_device_platform == "efr32" || chip_device_platform == "SiWx917") {
       defines += [ "CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE=${chip_enable_ble}" ]
     }
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -749,6 +749,20 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::ConfigureThreadS
     // If the Thread stack has been provisioned, but is not currently enabled, enable it now.
     if (otThreadGetDeviceRole(mOTInst) == OT_DEVICE_ROLE_DISABLED && otDatasetIsCommissioned(otInst))
     {
+        #if SL_USE_THREAD_DIRECT
+        // Set rx-off-when-idle directly here.
+        // The link mode default is rx-on-when-idle, and `otIp6SetEnabled()` below latches that
+        // default in OpenThread stack (`Mac::mRxOnWhenIdle` / `MeshForwarder::Start()`) before
+        // the device type is ever set.
+        {
+            otLinkModeConfig linkMode = otThreadGetLinkMode(otInst);
+
+            linkMode.mRxOnWhenIdle = false;
+            otErr                  = otThreadSetLinkMode(otInst, linkMode);
+            VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
+        }
+        #endif // SL_USE_THREAD_DIRECT
+
         // Enable the Thread IPv6 interface.
         otErr = otIp6SetEnabled(otInst, true);
         VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));

--- a/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
@@ -34,7 +34,7 @@
 
 #if SL_USE_THREAD_DIRECT
 #include <platform/silabs/address_resolve/PreCommissioning.h>
-#define TD_SLW_PERIOD_SLOT 64 // 500000 us (unit of slot duration 625 us).
+#define TD_SLW_PERIOD_SLOT 64 // 40000 us (unit of slot duration 625 us).
 // Should work at 64 (40 ms)
 #endif
 

--- a/src/platform/silabs/efr32/thread_direct.gni
+++ b/src/platform/silabs/efr32/thread_direct.gni
@@ -25,7 +25,7 @@ if (sl_use_thread_direct) {
   thread_direct_defines += [
     "SL_USE_THREAD_DIRECT=1",
     "OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE=1",
-    "OPENTHREAD_CONFIG_THREAD_DIRECT_SLW_TIMEOUT=1",
+    "OPENTHREAD_CONFIG_THREAD_DIRECT_SLW_TIMEOUT=200",
   ]
 
   if (chip_openthread_thread_direct_wake_initiator_enable) {

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -335,11 +335,9 @@ template("efr32_sdk") {
       if (sl_use_thread_direct) {
         if (chip_openthread_thread_direct_wake_listener_enable) {
           libs += [ "${efr32_sdk_root}/openthread/libs/listener/build/${compiler}/cortex-m33/sl-openthread-library/Release/libsl_openthread.a" ]
-          libs += [ "${efr32_sdk_root}/openthread/libs/listener/libsl_ot_stack_mtd_efr32mg24_${compiler}.a" ]
         } else {
           # chip_openthread_thread_direct_wake_initiator_enable
           libs += [ "${efr32_sdk_root}/openthread/libs/initiator/build/${compiler}/cortex-m33/sl-openthread-library/Release/libsl_openthread.a" ]
-          libs += [ "${efr32_sdk_root}/openthread/libs/initiator/libsl_ot_stack_mtd_efr32mg24_${compiler}.a" ]
         }
       } else {
         libs += [ "${efr32_sdk_root}/openthread/libs/build/${compiler}/cortex-m33/sl-openthread-library/Release/libsl_openthread.a" ]
@@ -385,11 +383,9 @@ template("efr32_sdk") {
       if (sl_use_thread_direct) {
         if (chip_openthread_thread_direct_wake_listener_enable) {
           libs += [ "${efr32_sdk_root}/openthread/libs/listener/build/${compiler}/cortex-m33/sl-openthread-library/Release/libsl_openthread.a" ]
-          libs += [ "${efr32_sdk_root}/openthread/libs/listener/libsl_ot_stack_mtd_efr32mg26_${compiler}.a" ]
         } else {
           # chip_openthread_thread_direct_wake_initiator_enable
           libs += [ "${efr32_sdk_root}/openthread/libs/initiator/build/${compiler}/cortex-m33/sl-openthread-library/Release/libsl_openthread.a" ]
-          libs += [ "${efr32_sdk_root}/openthread/libs/initiator/libsl_ot_stack_mtd_efr32mg26_${compiler}.a" ]
         }
       } else {
         libs += [ "${efr32_sdk_root}/openthread/libs/build/${compiler}/cortex-m33/sl-openthread-library/Release/libsl_openthread.a" ]


### PR DESCRIPTION
1. Add some wiring to be able to disable BLE at build time. This is not strictly needed, but I left it in since I experimented with it during testing.
2. Take @lpbeliveau-silabs 's changes to disable BLE at run time, while enabling it at build
3. Check in the "pure Thread dataset" pre-commissioning YAMLs that succeed.
4. Include a fix to set explicit rx-off-when-idle mode in a provisioned-role check in `GenericThreadStackManagerImpl_OpenThread.hpp`
5. Set `OPENTHREAD_CONFIG_THREAD_DIRECT_SLW_TIMEOUT=200 ms.`
6. Disable lib-based building (this is not strictly required but I was building with source).